### PR TITLE
Add yellow flair to heading

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -13,8 +13,9 @@ export default function Home() {
   return (
     <div className="min-h-screen font-sans bg-black flex flex-col">
       <section className="flex flex-col items-center justify-center py-24 text-center bg-gradient-to-b from-black to-black px-4">
-        <h1 className="text-5xl sm:text-6xl font-bold tracking-tight bg-gradient-to-r from-red-500 via-red-600 to-red-700 bg-clip-text text-transparent">
+        <h1 className="text-5xl sm:text-6xl font-bold tracking-tight bg-gradient-to-r from-yellow-400 via-red-600 to-yellow-400 bg-clip-text text-transparent flex items-center">
           Ink Portfolio
+          <span className="ml-2 text-yellow-300 animate-pulse">✨</span>
         </h1>
         <p className="mt-4 text-lg max-w-xl text-red-300">
           A selection of recent tattoos and designs.


### PR DESCRIPTION
## Summary
- tweak the hero text gradient to include yellow
- add a pulsing yellow star to the title

## Testing
- `npm install` *(fails: cannot reach registry)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892709e7b88327a5fb712282282537